### PR TITLE
adjusted config and changed the copy a bit

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -2,8 +2,8 @@
 * @type {import('vitepress').UserConfig}
 */
 export default {
-  title: "BSDG",
-  description: "Boise Software Developers Group",
+  title: "BSDG Inc",
+  description: "Boise Software Developers Group, Inc.",
 
   head: [
     ['link', { rel: 'icon', href: 'https://avatars.githubusercontent.com/u/8630126?s=400&u=2e5cdbb82946dbb4f1ae8db01b1e816b7756021a&v=4' }]
@@ -18,11 +18,6 @@ export default {
       provider: 'local'
     },
 
-    editLink: {
-      pattern: 'https://github.com/bsdg/www/edit/main/docs/:path'
-    },
-
-
     nav: [
       { text: 'Home', link: '/' },
       { text: 'About', link: '/about' },
@@ -32,7 +27,7 @@ export default {
       { icon: 'github', link: 'https://github.com/bsdg' },
       { icon: 'facebook', link: 'https://www.facebook.com/boisecodecamp' },
       { icon: 'discord', link: 'https://discord.gg/traxpMBsNn' },
-      { icon: 'twitter', link: 'https://bsky.app/profile/bsdg.dev' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/bsdg.dev' },
       { icon: 'linkedin', link: 'https://linkedin.com/company/boise-software-developer-group' },
     ],
 
@@ -40,7 +35,7 @@ export default {
       level: [2, 3],
     },
 
-    lastUpdated: true,
+    lastUpdated: false,
 
 
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -15,4 +15,4 @@ If you are interested in presenting a technology of interest to you at a meeting
 
 BSDG has operated as an informal organization since its start back in the late 1990s. In 2024, it formally organized as an Idaho Nonprofit entity and a Federal 501(c)(3) non-profit organization. In that process, it has also assumed organizational control of [Boise Code Camp](https://boisecodecamp.com), a yearly event held in the spring. BSDG helps to organize other events to serve local area developers. 
 
- 
+ <!--@include: ./board.md-->

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 ---
 title: Home
 description: Boise Software Developers Group
+layout: doc
+outline: false
 ---
 
 <center style="margin: 1em 0;">
@@ -11,8 +13,6 @@ description: Boise Software Developers Group
 
 ## Welcome to BSDG!
 
-The Boise Software Developers Group (BSDG) is a community of software developers in the Boise, Idaho area. We meet monthly to discuss software development topics, share knowledge, and network with other developers.
+Boise Software Developers Group, Inc. (BSDG) is a state and federal 501(c)3 non-profit organization with the mission of supporting and nurturing technical communities in and around Boise, ID.
 
-<!--@include: ./about.md-->
-
-<!--@include: ./board.md-->
+Born out of a longtime usergroup (BSDG) and a desire to bring events like [Boise Code Camp](https://boisecodecamp.com) back to the valley, the non-profit was founded in early 2024 to help our communities thrive again.


### PR DESCRIPTION
think the entry point (index) would be better with `layout: page` but likely needs some custom themeing or style there, it doesn't look good out the box, but as a doc with no table of contents the content doesn't center properly, can you investigate @jakeoverall 

Also we likely want to change the copy on the about page, its all about the group not the non profit, probably want to talk about our broader mission not just BSDG

I also changed some text to specifically say BSDG Inc given that it is separate from BSDG the user group